### PR TITLE
Make stderr redirection compatible with Fish 3.0.

### DIFF
--- a/functions/fenv.main.fish
+++ b/functions/fenv.main.fish
@@ -26,7 +26,7 @@ function fenv.main
   set divider (fenv.parse.divider)
   set previous_env (bash -c 'env')
 
-  set program_execution (bash -c "$program && (echo; echo '$divider'; env)" ^&1)
+  set program_execution (bash -c "$program && (echo; echo '$divider'; env)" 2>&1)
   set program_status $status
 
   if not contains -- "$divider" $program_execution


### PR DESCRIPTION
Fish has deprecated `^` as a shortcut for stderr redirection in 3.0. Replace it with the more
compatible `2>`.

See oh-my-fish/oh-my-fish#609 and oh-my-fish/oh-my-fish#618