### PR TITLE
Fix spurious SHLVL variable assignment by fenv (alternate method)

### DIFF
--- a/functions/fenv.apply.fish
+++ b/functions/fenv.apply.fish
@@ -30,6 +30,11 @@ function fenv.apply
 
         if test "$key" = 'PATH'
           set value (echo $value | tr ':' '\n')
+        # else if test "$key" = "SHLVL"
+        #   # False difference created by running the `env` command at different
+        #   # shell levels.
+        #   # Avoids warning message in fish 3.0 that SHLVL is read-only.
+        #   continue
         end
 
         set -g -x $key $value


### PR DESCRIPTION
This is an alternative to #19 that solves the same issue in a different way.

Skips assigning the SHLVL variable if it is the assignment list.

The 2nd `env` call is made within one additional bash subshell
causing the SHLVL variable to differ and therefore be included in the diff.

In fish 3.0 this assignment resulted in a warning message because SHLVL is read only.