### PR TITLE
Fix inconsistency on env stderr output

### DIFF
--- a/functions/fenv.main.fish
+++ b/functions/fenv.main.fish
@@ -24,7 +24,7 @@
 function fenv.main
   set program $argv
   set divider (fenv.parse.divider)
-  set previous_env (bash -c 'env')
+  set previous_env (bash -c 'env' 2>&1)
 
   # Need to ensure that the two calls to env (here and above) have the same
   # nesting level within bash shells so that the SHLVL variable does not differ.


### PR DESCRIPTION
It is possible for env to produce output on stderr.
I don't know the precise condition, but it is triggered by the Environment Modules [Bash initialization script](https://github.com/cea-hpc/modules/blob/master/init/bash.in)
`previous_env` did not capture stderr while `program_execution` does,
so there would be spurious diffs when env outputs to stderr.

This fixes that by capturing stderr in `previous_env` as well.