### PR TITLE
Don't try to assign _

### DIFF
--- a/functions/fenv.parse.diff.fish
+++ b/functions/fenv.parse.diff.fish
@@ -26,6 +26,10 @@ function fenv.parse.diff
   set -l after (fenv.parse.after $argv)
 
   for environment in $after
+    # Skip the _ variable to avoid 
+    if string match -q -- "_=*" "$environment"
+      continue
+    end
     if not contains -- "$environment" $before
       echo $environment
     end


### PR DESCRIPTION
## Before this PR

There were some cases where we'd still try to set `_` unsuccessfully, e.g. when sourcing the per-user nix.sh file when running a Nix installation.
See https://github.com/oh-my-fish/plugin-foreign-env/pull/19#issuecomment-591451790

With some debugging messages printed out as to what it was returning from `fenv.parse.diff`:
```
Setting: NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
Setting: PATH=/Users/dansanduleac/.nix-profile/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
Setting: _=/Users/dansanduleac/.nix-profile/bin/env
set: Tried to change the read-only variable “_”
```

## After this PR

Always filter out `_` from being set in fish.

Actually fixes what https://github.com/oh-my-fish/plugin-foreign-env/pull/19 tried to achieve.