### PR TITLE
feature: print output instead of executing

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,20 @@ When commands aren't double quoted, you need to escape semicolon with slash `\;`
 fenv "source ~/.nvm/nvm.sh; nvm --help"
 ```
 
+You can also choose to print the output instead of setting the environment:
+
+```fish
+fenv -p export PYTHON=python2
+```
+
+will print
+
+```fish
+set -g -x PYTHON python2
+```
+
+instead of executing the command. This can be used to translate a foreign environment file to a native fish file.
+
 
 # Caveats
 

--- a/functions/fenv.fish
+++ b/functions/fenv.fish
@@ -27,7 +27,15 @@ function fenv -d "Run bash scripts and import variables modified by them"
       return 0
     end
 
-    fenv.main $argv
+    argparse 'p/print' -- $argv
+
+    if test -n $_flag_print
+      set operation "print"
+    else
+      set operation "apply"
+    end
+
+    fenv.main $operation $argv
     return $status
   else
     echo (set_color red)'error:' (set_color normal)'parameter missing'

--- a/functions/fenv.main.fish
+++ b/functions/fenv.main.fish
@@ -21,8 +21,8 @@
 # SOFTWARE.
 
 
-function fenv.main
-  set program $argv
+function fenv.main -a operation -a rest
+  set program $rest
   set divider (fenv.parse.divider)
   set previous_env (bash -c 'env')
 
@@ -45,7 +45,14 @@ function fenv.main
 
   set new_env (fenv.parse.after $program_execution)
 
-  fenv.apply (fenv.parse.diff $previous_env $divider $new_env)
+  if [ $operation = "apply" ]
+    fenv.apply (fenv.parse.diff $previous_env $divider $new_env)
+  else if [ $operation = "print" ]
+    fenv.print (fenv.parse.diff $previous_env $divider $new_env)
+  else
+    printf "Invalid command: %s\n" $operation
+    return $program_status
+  end
 
   test (count $program_output) -gt 1
     and printf "%s\n" $program_output[1..-2]

--- a/functions/fenv.print.fish
+++ b/functions/fenv.print.fish
@@ -1,0 +1,18 @@
+function fenv.print
+    set variables $argv
+
+    set output ()
+
+    for variable in $variables
+        set key (echo $variable | sed 's/=.*//')
+        set value (echo $variable | sed 's/[^=]*=//')
+
+        if test "$key" = 'PATH'
+          set value (echo $value | tr ':' '\n')
+        end
+
+        set -a output "set -g -x $key $value"
+    end
+
+    string join \n $output
+end


### PR DESCRIPTION
This pull requests adds a `-p`/`--print` flag to fenv which allows for outputting the `set` commands generated instead of executing them.

The motivation for this way to move the calls to `fenv` from shell start time to configuration generation time in [nix](https://github.com/LnL7/nix-darwin/blob/828879f93084fdd5b12925acc016497d2410bdc4/modules/programs/fish.nix#L113).

It's a bit expensive to call `fenv` on every shell launch, but it would be possible to translate the bash environment file once and cache the result as native fish `set` commands.