### PR TITLE
fix: skip variables with invalid names

### DIFF
--- a/functions/fenv.main.fish
+++ b/functions/fenv.main.fish
@@ -27,6 +27,8 @@ function fenv.main
     # Skip read-only variables
     contains $kv[1] _ SHLVL PWD; and continue
     string match -rq '^BASH_.*%%$' $kv[1]; and continue
+    # Skip variables with invalid names
+    string match -rq '^[a-zA-Z0-9_]+$' $kv[1]; or continue
     # Variable
     # - is not defined
     # - OR variable differs

--- a/test/cases/003_handle_edge_cases_and_variable_scopes.fish
+++ b/test/cases/003_handle_edge_cases_and_variable_scopes.fish
@@ -20,3 +20,5 @@ it_should "return both stdout and stderr" \
   'test $both = error\ntest; and test $test = a'
 it_should "work with variables used by main function" \
   'fenv export env_var=a\; export kv=a; set -qgx env_var; and set -qgx kv; and test $env_var = a -a $kv = a'
+it_should "skip variables with invalid names" \
+  'set -l output (env "foo-bar=123" fish -N -c "set fish_function_path -p ./functions; fenv \'export valid_var=456\'; and echo \$valid_var" 2>&1); test "$output" = 456'


### PR DESCRIPTION
Variables containing hyphens (e.g., 'CLOUDSDK_VMWARE_NODE-TYPE' when connecting to GCP) or other special characters are invalid in Fish, causing syntax errors in 'set -gx'. Check variable names against a standard pattern and ignore invalid ones.